### PR TITLE
Card:新建每周发生的活动并查看

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 /build/
+/bin/
 classes/
 !gradle/wrapper/gradle-wrapper.jar
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ classes/
 *.iml
 *.ipr
 
+### Visual Studio Code ###
+.vscode
+
 ### NetBeans ###
 nbproject/private/
 build/

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,11 @@ task febuild (type: Exec, description: 'Runs the front-end webpack build.', grou
     commandLine 'yarn', 'bundle:prod'
 }
 
+task devbuild (type: Exec, description: 'Runs the front-end webpack build development.', group: 'Verification') {
+    workingDir 'src/websrc'
+    commandLine 'yarn', 'bundle'
+}
+
 applicationDefaultJvmArgs = ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"]
 
 jacoco {
@@ -144,11 +149,16 @@ integration {
     systemProperties['spring.profiles.active']='test'
 }
 
-compileJava.dependsOn febuild
+if ("$env" == 'dev') {
+  println 'In development mode...'
+  compileJava.dependsOn devbuild
+} else {
+  println 'In production mode...'
+  compileJava.dependsOn febuild
+}
 
 check.dependsOn integration
 integration.mustRunAfter test
-
 
 test {
     environment 'MYSQL_HOST', '127.0.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,7 @@ integration {
     systemProperties['spring.profiles.active']='test'
 }
 
-if ("$env" == 'dev') {
+if (project.hasProperty('env') && env == 'dev') {
   println 'In development mode...'
   compileJava.dependsOn devbuild
 } else {

--- a/localrun.sh
+++ b/localrun.sh
@@ -6,4 +6,4 @@ yarn install
 yarn bundle-watch &
 yarn server &
 cd ./../..
-./gradlew clean bootRun -P env=dev
+./gradlew clean bootRun -Penv=dev

--- a/localrun.sh
+++ b/localrun.sh
@@ -6,4 +6,4 @@ yarn install
 yarn bundle-watch &
 yarn server &
 cd ./../..
-./gradlew clean bootRun
+./gradlew clean bootRun -P env=dev

--- a/shutdownHtmlWatch.sh
+++ b/shutdownHtmlWatch.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
 function cleanup {
-    webpackPids=$(ps aux | grep "^webpack --watch$" | awk '{ print $2 }')
+    webpackPids=$(ps aux | grep "webpack-dev-server" | awk '{ print $2 }')
     count=0
     echo "begin closing"
     if [ -n "${webpackPids}" ]; then
         echo "Killing existing webpack background process with PID [${webpackPids}]"
         for pid in $webpackPids
         do
-            count = count + 1
+            count=`expr $count + 1`
             echo $pid
             kill -9 $pid
         done
-        echo "things being closed:${pid}"
+        echo "things being closed:${count}"
     fi
     echo "end closing"
 }

--- a/shutdownHtmlWatch.sh
+++ b/shutdownHtmlWatch.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 
 function cleanup {
-    webpackPids=$(ps aux | grep "webpack --watch" | awk '{ print $2 }')
-
+    webpackPids=$(ps aux | grep "^webpack --watch$" | awk '{ print $2 }')
+    count=0
+    echo "begin closing"
     if [ -n "${webpackPids}" ]; then
         echo "Killing existing webpack background process with PID [${webpackPids}]"
         for pid in $webpackPids
         do
+            count = count + 1
             echo $pid
             kill -9 $pid
         done
+        echo "things being closed:${pid}"
     fi
+    echo "end closing"
 }
 cleanup
 trap cleanup EXIT

--- a/src/main/java/com/tw/wh/devops/domains/Activity.java
+++ b/src/main/java/com/tw/wh/devops/domains/Activity.java
@@ -17,11 +17,11 @@ public class Activity {
     private String imageURL;
     private String status;
     private String location;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Shanghai")
     private Date startTime;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Shanghai")
     private Date endTime;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Shanghai")
     private Date createTime;
     private String owner;
     private byte displayTime;

--- a/src/main/java/com/tw/wh/devops/domains/Activity.java
+++ b/src/main/java/com/tw/wh/devops/domains/Activity.java
@@ -28,6 +28,7 @@ public class Activity {
     private String description;
     @Enumerated(EnumType.STRING)
     private ActivityType type;
+    private Boolean weeklyRepeat;
 
     public Activity() {
     }
@@ -104,9 +105,13 @@ public class Activity {
         this.endTime = endTime;
     }
 
-    public Date getCreateTime() { return createTime; }
+    public Date getCreateTime() {
+        return createTime;
+    }
 
-    public void setCreateTime(Date createTime) { this.createTime = createTime; }
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
+    }
 
     public String getDescription() {
         return description;
@@ -116,16 +121,32 @@ public class Activity {
         this.description = description;
     }
 
-    public String getOwner() { return owner; }
+    public String getOwner() {
+        return owner;
+    }
 
-    public void setOwner(String owner) { this.owner = owner; }
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
 
-    public byte getDisplayTime() { return displayTime; }
+    public byte getDisplayTime() {
+        return displayTime;
+    }
 
-    public void setDisplayTime(byte displayTime) { this.displayTime = displayTime; }
+    public void setDisplayTime(byte displayTime) {
+        this.displayTime = displayTime;
+    }
 
     public ActivityType getType() {
         return type;
+    }
+
+    public Boolean getWeeklyRepeat() {
+        return weeklyRepeat;
+    }
+
+    public void setWeeklyRepeat(Boolean weeklyRepeat) {
+        this.weeklyRepeat = weeklyRepeat;
     }
 
     public void setType(ActivityType type) {
@@ -134,21 +155,10 @@ public class Activity {
 
     @Override
     public String toString() {
-        return "Activity{" +
-                "id=" + id +
-                ", name='" + name + '\'' +
-                ", sponsor='" + sponsor + '\'' +
-                ", guest='" + guest + '\'' +
-                ", imageURL='" + imageURL + '\'' +
-                ", status='" + status + '\'' +
-                ", location='" + location + '\'' +
-                ", startTime=" + startTime +
-                ", endTime=" + endTime +
-                ", description='" + description + '\'' +
-                ", type=" + type +
-                ", createTime=" + createTime +
-                ", owner='" + owner + '\'' +
-                ", displayTime=" + displayTime +
-                '}';
+        return "Activity{" + "id=" + id + ", name='" + name + '\'' + ", sponsor='" + sponsor + '\'' + ", guest='"
+                + guest + '\'' + ", imageURL='" + imageURL + '\'' + ", status='" + status + '\'' + ", location='"
+                + location + '\'' + ", startTime=" + startTime + ", endTime=" + endTime + ", description='"
+                + description + '\'' + ", type=" + type + ", createTime=" + createTime + ", owner='" + owner + '\''
+                + ", displayTime=" + displayTime + ", weeklyRepeat=" + weeklyRepeat + '}';
     }
 }

--- a/src/main/java/com/tw/wh/devops/repositories/ActivityRepository.java
+++ b/src/main/java/com/tw/wh/devops/repositories/ActivityRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -15,4 +16,8 @@ import java.util.Date;
 public interface ActivityRepository extends JpaRepository<Activity, Long> {
     @Query("SELECT a FROM Activity a WHERE a.startTime >= :startTime")
     Page<Activity> findAllWithStartTimeLaterThan(@Param("startTime") Date startTime, Pageable pageable);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Activity a SET a.startTime = TIMESTAMPADD(DAY, CEIL(TIMESTAMPDIFF(DAY, a.startTime, NOW())/7.0) * 7, a.startTime), end_time = TIMESTAMPADD(DAY, CEIL(TIMESTAMPDIFF(DAY, a.startTime, NOW())/7.0) * 7, end_time) WHERE a.startTime < NOW() AND a.weeklyRepeat = 1")
+    void updateWeeklyActivityStartTime();
 }

--- a/src/main/java/com/tw/wh/devops/rest/controller/ActivitiesController.java
+++ b/src/main/java/com/tw/wh/devops/rest/controller/ActivitiesController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Calendar;
@@ -21,6 +22,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.*;
 @CrossOrigin(origins = "${cross.origin.url}")
 @RestController
 @RequestMapping("/v1/activities")
+@Transactional
 public class ActivitiesController {
 
     @Autowired
@@ -33,6 +35,7 @@ public class ActivitiesController {
                                   @RequestParam(required = false, defaultValue = "") String type,
                                   @RequestParam(required = false, defaultValue = "") String status,
                                   @RequestParam(required = false, defaultValue = "false") boolean validation, Sort sort) {
+        activityRepository.updateWeeklyActivityStartTime();
         PageRequest pageRequest = new PageRequest(page, size, sort);
         Page<Activity> all;
         if (validation) {

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -10,7 +10,7 @@ spring.jpa.hibernate.ddl-auto=none
 flyway.enabled=true
 flyway.locations=classpath:db/migration/dev
 
-spring.datasource.url=jdbc:h2:file:~/dev_17high;MODE=MySQL;IGNORECASE=TRUE;
+spring.datasource.url=jdbc:h2:file:~/dev_17high;IGNORECASE=TRUE;
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -10,7 +10,7 @@ spring.jpa.hibernate.ddl-auto=none
 flyway.enabled=true
 flyway.locations=classpath:db/migration/dev
 
-spring.datasource.url=jdbc:h2:file:~/dev_17high;IGNORECASE=TRUE;
+spring.datasource.url=jdbc:h2:file:~/dev_17high;MODE=MySQL;IGNORECASE=TRUE;
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=

--- a/src/main/resources/db/migration/dev/V1_4__alter_table_activity_weeklyRepeat.sql
+++ b/src/main/resources/db/migration/dev/V1_4__alter_table_activity_weeklyRepeat.sql
@@ -1,0 +1,1 @@
+ALTER TABLE activity ADD COLUMN weekly_repeat TINYINT(1) DEFAULT 0;

--- a/src/main/resources/db/migration/prod/V1_3__update_data.sql
+++ b/src/main/resources/db/migration/prod/V1_3__update_data.sql
@@ -1,0 +1,9 @@
+UPDATE activity SET create_time='2017-06-15 22:00:00', start_time='2017-06-16 22:00:00' WHERE id=1;
+UPDATE activity SET create_time='2017-06-18 22:00:00', start_time='2017-06-17 22:00:00' WHERE id=2;
+UPDATE activity SET create_time='2017-05-16 22:00:00', start_time='2017-06-18 22:00:00' WHERE id=3;
+UPDATE activity SET create_time='2017-05-17 22:00:00', start_time='2017-06-29 12:00:00' WHERE id=4;
+UPDATE activity SET create_time='2017-06-22 22:00:00', start_time='2017-06-29 23:00:00' WHERE id=5;
+UPDATE activity SET create_time='2017-06-10 22:00:00', start_time='2017-06-21 22:00:00' WHERE id=6;
+UPDATE activity SET create_time='2017-05-18 22:00:00', start_time='2017-06-16 23:00:00' WHERE id=7;
+UPDATE activity SET create_time='2017-05-20 22:00:00', start_time='2017-06-18 20:00:00' WHERE id=8;
+UPDATE activity SET create_time='2017-05-29 22:00:00', start_time='2017-06-11 22:00:00' WHERE id=9;

--- a/src/main/resources/db/migration/prod/V1_4__alter_table_activity_weeklyRepeat.sql
+++ b/src/main/resources/db/migration/prod/V1_4__alter_table_activity_weeklyRepeat.sql
@@ -1,0 +1,1 @@
+ALTER TABLE activity ADD COLUMN weekly_repeat TINYINT(1) DEFAULT 0;

--- a/src/websrc/.eslintrc.json
+++ b/src/websrc/.eslintrc.json
@@ -5,7 +5,7 @@
     "react"
   ],
   "rules": {
-    "comma-dangle": ["error", "never"],
+    "comma-dangle": ["error", "always-multiline"],
     "semi": [2, "always"],
     "react-in-jsx-scope": 0,
     "no-unused-expressions": [2, {"allowShortCircuit": true}],

--- a/src/websrc/package.json
+++ b/src/websrc/package.json
@@ -62,7 +62,7 @@
     "react-datetime": "^2.8.8",
     "react-dom": "^15.4.2",
     "react-intl": "^2.3.0",
-    "react-router": "^2.8.1"
+    "react-router": "3.0.5"
   },
   "scripts": {
     "start": "yarn clean-dist && webpack && webpack-dev-server --inline --hot",

--- a/src/websrc/package.json
+++ b/src/websrc/package.json
@@ -61,6 +61,7 @@
     "react": "^15.4.2",
     "react-datetime": "^2.8.8",
     "react-dom": "^15.4.2",
+    "react-intl": "^2.3.0",
     "react-router": "^2.8.1"
   },
   "scripts": {

--- a/src/websrc/src/components/DashboardComponent/EventList/eventList.scss
+++ b/src/websrc/src/components/DashboardComponent/EventList/eventList.scss
@@ -106,3 +106,10 @@ $font-weight: 100;
   font-size: 16px;
   color: darkgrey;
 }
+
+.activity-display-time {
+  line-height: 25px;
+  font-weight: 100;
+  font-size: 16px;
+  color: darkgrey;
+}

--- a/src/websrc/src/components/DashboardComponent/EventList/index.jsx
+++ b/src/websrc/src/components/DashboardComponent/EventList/index.jsx
@@ -1,10 +1,10 @@
 import React, {Component} from "react";
-import { FormattedMessage } from 'react-intl';
+import {FormattedMessage} from "react-intl";
 import {Link} from "react-router";
 import PropTypes from "prop-types";
 import classNames from "classnames/bind";
-import $ from 'jquery';
-import Preview from '../PreviewComponent/'
+import $ from "jquery";
+import Preview from "../PreviewComponent/";
 
 import ActivityApiService from "../../services/ActivityApiService";
 import scss from "./eventList.scss";
@@ -103,6 +103,7 @@ class EventList extends Component {
                     className={ cx('activity-loc-time') }>{ activity.type === 'SESSION' ? sessionTimeTemp(activity.location, activity.sponsor) : newsTimeTemp(startTime, endTime) }</div>
                   <div className={ cx('activity-desc') }>{ activity.description }</div>
                   <div className={ cx('activity-owner') }>{ createTime } { activity.owner } <FormattedMessage id="dashboard_label_post" /></div>
+                  <div className={ cx('activity-display-time') }>{ activity.displayTime + 's' }</div>
                   <br />
                 </div>
               );
@@ -146,12 +147,16 @@ class EventList extends Component {
   }
 
   updateDisplayTime = (time, evt) => {
-    let id = evt.target.getAttribute('data-id');
-
-    let items = this.state.items;
+    let id = evt.target.parentElement.getAttribute('data-id');
     let item = this.state.items.filter(item => item.id.toString() === id);
-    ActivityApiService.updateActivity(`/v1/activities/${id}`,
-      JSON.stringify({...item[0], displayTime: time}), () => $('#options')[0].style.display = 'none');
+    ActivityApiService.updateActivity(`/v1/activities/${id}`, JSON.stringify({
+        ...item[0],
+        displayTime: time
+      }),
+      () => {
+        $('#options')[0].style.display = 'none';
+      }
+    );
   }
 
   fetchData = (url, callback) => {

--- a/src/websrc/src/components/DashboardComponent/EventList/index.jsx
+++ b/src/websrc/src/components/DashboardComponent/EventList/index.jsx
@@ -54,7 +54,7 @@ class EventList extends Component {
     return (
       <div className={cx('event-list-container')}>
         {
-          this.state.items.map((activity) => {
+          this.state.items.map((activity, index) => {
             const startTime = formatDate(activity.startTime);
             const endTime = formatDate(activity.endTime);
             const createTime = formatDate(activity.createTime);
@@ -108,7 +108,7 @@ class EventList extends Component {
               );
             }
 
-            return <div key="unknown-activity-type"><FormattedMessage id="dashboard_warn_unknown_type" /></div>;
+            return <div key={`unknown-activity-type-${index}`}><FormattedMessage id="dashboard_warn_unknown_type" /></div>;
           })
         }
         <Dialog

--- a/src/websrc/src/components/DashboardComponent/EventList/index.jsx
+++ b/src/websrc/src/components/DashboardComponent/EventList/index.jsx
@@ -1,4 +1,5 @@
 import React, {Component} from "react";
+import { FormattedMessage } from 'react-intl';
 import {Link} from "react-router";
 import PropTypes from "prop-types";
 import classNames from "classnames/bind";
@@ -57,8 +58,20 @@ class EventList extends Component {
             const startTime = formatDate(activity.startTime);
             const endTime = formatDate(activity.endTime);
             const createTime = formatDate(activity.createTime);
-            const sessionTimeTemp = (loc, sponsor) => `活动时间:${startTime} - ${endTime} 活动地点:${loc} 主办方:${sponsor}`;
-            const newsTimeTemp = () => `展示时间:${startTime} - ${endTime}`;
+            const sessionTimeTemp = (loc, sponsor) => <FormattedMessage
+              id="dashboard_session_time"
+              values={{
+                startTime,
+                endTime,
+                loc,
+                sponsor
+              }} />;
+            const newsTimeTemp = () => <FormattedMessage
+              id="dashboard_news_time"
+              values={{
+                startTime,
+                endTime
+              }} />;
 
             if (activity.type) {
               return (
@@ -69,33 +82,33 @@ class EventList extends Component {
                       className={ cx('option') }
                       id={ activity.id }
                       onClick={ this.handlePreviewClick }>
-                      预览
+                      <FormattedMessage id="dashboard_preview" />
                     </button>
-                    <button className={ cx('option') }><Link to={ 'editor/' + activity.id }>编辑</Link></button>
+                    <button className={ cx('option') }><Link to={ 'editor/' + activity.id }><FormattedMessage id="dashboard_edit" /></Link></button>
                     <button
                       className={ cx('option') }
                       id={ activity.id }
                       onClick={ this.handleDeleteClick }>
-                      删除
+                      <FormattedMessage id="dashboard_delete" />
                     </button>
                     <div className={ cx('display-time') }>
-                      <button>播放10S</button>
+                      <button><FormattedMessage id="dashboard_display_10s" /></button>
                       <div id="options" className={ cx('options') }>
-                        <a data-id={ activity.id } onClick={ (evt) => this.updateDisplayTime(10, evt) }>播放10S</a>
-                        <a data-id={ activity.id } onClick={ (evt) => this.updateDisplayTime(20, evt) }>播放20S</a>
+                        <a data-id={ activity.id } onClick={ (evt) => this.updateDisplayTime(10, evt) }><FormattedMessage id="dashboard_display_10s" /></a>
+                        <a data-id={ activity.id } onClick={ (evt) => this.updateDisplayTime(20, evt) }><FormattedMessage id="dashboard_display_20s" /></a>
                       </div>
                     </div>
                   </div>
                   <div
                     className={ cx('activity-loc-time') }>{ activity.type === 'SESSION' ? sessionTimeTemp(activity.location, activity.sponsor) : newsTimeTemp(startTime, endTime) }</div>
                   <div className={ cx('activity-desc') }>{ activity.description }</div>
-                  <div className={ cx('activity-owner') }>{ createTime } { activity.owner } 发布</div>
+                  <div className={ cx('activity-owner') }>{ createTime } { activity.owner } <FormattedMessage id="dashboard_label_post" /></div>
                   <br />
                 </div>
               );
             }
 
-            return <div key="unknown-activity-type">未知的活动类型</div>;
+            return <div key="unknown-activity-type"><FormattedMessage id="dashboard_warn_unknown_type" /></div>;
           })
         }
         <Dialog

--- a/src/websrc/src/components/DashboardComponent/FilterDropDown/index.jsx
+++ b/src/websrc/src/components/DashboardComponent/FilterDropDown/index.jsx
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 
@@ -6,8 +7,8 @@ import scss from './filterDropDown.scss';
 
 const cx = classNames.bind(scss);
 const TEXT_MAPPER = {
-  createTime: '按活动发布时间排序',
-  startTime: '按活动开始时间排序'
+  createTime: <FormattedMessage id="dashboard_label_sort_by_post_time" />,
+  startTime: <FormattedMessage id="dashboard_label_sort_by_start_time" />
 };
 
 class FilterDropDown extends PureComponent {

--- a/src/websrc/src/components/DashboardComponent/NotificationComponent/index.jsx
+++ b/src/websrc/src/components/DashboardComponent/NotificationComponent/index.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
 import $ from 'jquery';
 import classNames from 'classnames/bind';
 import styles from '../../css/notification.scss';
@@ -20,13 +21,13 @@ class NotificationComponent extends Component {
 
   generateNotification() {
     if (window.location.hash.match('activityPublished')) {
-      return this.notificationTemplate('活动发布成功');
+      return this.notificationTemplate(<FormattedMessage id="dashboard_label_post_success" />);
     } else if (window.location.hash.match('activityUpdated')) {
-      return this.notificationTemplate('活动更新成功');
+      return this.notificationTemplate(<FormattedMessage id="dashboard_label_update_success" />);
     } else if (window.location.hash.match('newsPublished')) {
-      return this.notificationTemplate('新闻发布成功');
+      return this.notificationTemplate(<FormattedMessage id="dashboard_label_post_news_success" />);
     } else if (window.location.hash.match('newsUpdated')) {
-      return this.notificationTemplate('新闻更新成功');
+      return this.notificationTemplate(<FormattedMessage id="dashboard_label_update_news_success" />);
     } else {
       return (<div></div>);
     }

--- a/src/websrc/src/components/DashboardComponent/PreviewComponent/PreviewDetailComponent.jsx
+++ b/src/websrc/src/components/DashboardComponent/PreviewComponent/PreviewDetailComponent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import scss from './PreviewComponent.scss';
 import NewsIcon from '../../ScreenComponent/svg/NewsIcon';
@@ -53,17 +54,17 @@ const PreviewDetailComponent = (props) => {
 };
 
 PreviewDetailComponent.propTypes = {
-  activity: React.PropTypes.shape({
-    sponsor: React.PropTypes.string,
-    location: React.PropTypes.string,
-    guest: React.PropTypes.string,
-    description: React.PropTypes.string,
-    endTime: React.PropTypes.date,
-    name: React.PropTypes.string,
-    type: React.PropTypes.string,
-    imageURL: React.PropTypes.string
+  activity: PropTypes.shape({
+    sponsor: PropTypes.string,
+    location: PropTypes.string,
+    guest: PropTypes.string,
+    description: PropTypes.string,
+    endTime: PropTypes.date,
+    name: PropTypes.string,
+    type: PropTypes.string,
+    imageURL: PropTypes.string
   }).isRequired,
-  addition: React.PropTypes.string.isRequired
+  addition: PropTypes.string.isRequired
 };
 
 

--- a/src/websrc/src/components/DashboardComponent/locale/zh.js
+++ b/src/websrc/src/components/DashboardComponent/locale/zh.js
@@ -1,0 +1,18 @@
+export default {
+  dashboard_session_time: '活动时间:{startTime} - {endTime} 活动地点:{loc} 主办方:{sponsor}',
+  dashboard_news_time: '展示时间:{startTime} - {endTime}',
+  dashboard_event_session: '活动',
+  dashboard_preview: '预览',
+  dashboard_edit: '编辑',
+  dashboard_delete: '删除',
+  dashboard_display_10s: '播放10S',
+  dashboard_display_20s: '播放20S',
+  dashboard_label_post: '发布',
+  dashboard_warn_unknown_type: '未知的活动类型',
+  dashboard_label_sort_by_post_time: '按活动发布时间排序',
+  dashboard_label_sort_by_start_time: '按活动开始时间排序',
+  dashboard_label_post_success: '活动发布成功',
+  dashboard_label_update_success: '活动更新成功',
+  dashboard_label_post_news_success: '新闻发布成功',
+  dashboard_label_update_news_success: '新闻更新成功'
+};

--- a/src/websrc/src/components/Editor/ActivityEditor.jsx
+++ b/src/websrc/src/components/Editor/ActivityEditor.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import 'jquery-validation';
 import classNames from 'classnames/bind';
 
@@ -16,7 +17,7 @@ class ActivityEditor extends EditorBase {
     return (
       <div>
         <div className={cx('inputBlock')}>
-          {this.getInputName('活动名称', true)}
+          {this.getInputName(<FormattedMessage id="session_name" />, true)}
           <div>
             <input
               name="name" className={cx('newsNameInput')} type="text"
@@ -26,14 +27,14 @@ class ActivityEditor extends EditorBase {
           </div>
         </div>
         <div className={cx('inputBlock')}>
-          {this.getInputName('活动时间', true)}
+          {this.getInputName(<FormattedMessage id="session_time_range" />, true)}
           <div>
             {this.getDateInput()}
-            <div className='invalidTimeError'>活动时间不能为空且结束时间不能早于开始时间</div>
+            <div className='invalidTimeError'><FormattedMessage id="invalid_time_error" /></div>
           </div>
         </div>
         <div className={cx('inputBlock')}>
-          {this.getInputName('活动地点', true)}
+          {this.getInputName(<FormattedMessage id="session_location" />, true)}
           <div>
             <input
               name="location" className={cx('newsNameInput')} type="text"
@@ -43,7 +44,7 @@ class ActivityEditor extends EditorBase {
           </div>
         </div>
         <div className={cx('inputBlock')}>
-          {this.getInputName('主办方', true)}
+          {this.getInputName(<FormattedMessage id="session_host" />, true)}
           <div>
             <input
               name="sponsor" className={cx('newsNameInput')} type="text"
@@ -53,7 +54,7 @@ class ActivityEditor extends EditorBase {
           </div>
         </div>
         <div className={cx('inputBlock')}>
-          {this.getInputName('活动嘉宾', false)}
+          {this.getInputName(<FormattedMessage id="session_guest" />, false)}
           <div>
             <input
               name="guest" className={cx('newsNameInput')} type="text"
@@ -63,7 +64,7 @@ class ActivityEditor extends EditorBase {
           </div>
         </div>
         <div className={cx('inputBlock')}>
-          {this.getInputName('活动描述', true)}
+          {this.getInputName(<FormattedMessage id="session_description" />, true)}
           <div>
             <textarea
               name="description" className={cx('newsDescriptionInput')} type="text"

--- a/src/websrc/src/components/Editor/ActivityEditor.jsx
+++ b/src/websrc/src/components/Editor/ActivityEditor.jsx
@@ -30,6 +30,9 @@ class ActivityEditor extends EditorBase {
           {this.getInputName(<FormattedMessage id="session_time_range" />, true)}
           <div>
             {this.getDateInput()}
+            <div className={cx('inputBlock')}>
+              <input type="checkbox" className={cx('inputCheck')} name="weeklyRepeat" value={this.getChecked()} onChange={event => this.handleInputChange(event)} />每周重复
+            </div>
             <div className='invalidTimeError'><FormattedMessage id="invalid_time_error" /></div>
           </div>
         </div>

--- a/src/websrc/src/components/Editor/ActivityEditor.jsx
+++ b/src/websrc/src/components/Editor/ActivityEditor.jsx
@@ -31,7 +31,7 @@ class ActivityEditor extends EditorBase {
           <div>
             {this.getDateInput()}
             <div className={cx('inputBlock')}>
-              <input type="checkbox" className={cx('inputCheck')} name="weeklyRepeat" value={this.getChecked()} onChange={event => this.handleInputChange(event)} />每周重复
+              <input type="checkbox" className={cx('inputCheck')} name="weeklyRepeat" checked={this.getChecked('weeklyRepeat')} onChange={event => this.handleInputChange(event)} />每周重复
             </div>
             <div className='invalidTimeError'><FormattedMessage id="invalid_time_error" /></div>
           </div>

--- a/src/websrc/src/components/Editor/EditorBase.jsx
+++ b/src/websrc/src/components/Editor/EditorBase.jsx
@@ -310,6 +310,11 @@ class EditorBase extends React.Component {
     return currentEvent && currentEvent[attrName] && currentEvent[attrName].substr(11);
   }
 
+  getChecked(attrName) {
+    let currentEvent = this.state.currentEvent;
+    return currentEvent && currentEvent[attrName];
+  }
+
   handleInputChange(event) {
     const target = event.target;
     const value = target.type === 'checkbox' ? target.checked : target.value;

--- a/src/websrc/src/components/Editor/EditorBase.jsx
+++ b/src/websrc/src/components/Editor/EditorBase.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import $ from 'jquery';
 import 'jquery-validation';
 import Moment from 'moment';
@@ -66,12 +67,12 @@ class EditorBase extends React.Component {
               alt=""
               className={cx('previewIcon')}
               src={previewImg} />
-            <div className={cx('previewText')}>预览看看</div>
+            <div className={cx('previewText')}><FormattedMessage id="preview" /></div>
           </div>
         </div>
         <div className={cx('newsSubmit')}>
           <button type="button" className={cx('publish')} onClick={this.publishEvent}>{ this.getPublishTitle() }</button>
-          <button type="button" className={cx('cancelPublish')} onClick={ this.cancelPublish}>取消</button>
+          <button type="button" className={cx('cancelPublish')} onClick={ this.cancelPublish}><FormattedMessage id="cancel" /></button>
         </div>
         <Preview
           ref={ preview => this.preview = preview }>
@@ -121,7 +122,7 @@ class EditorBase extends React.Component {
   }
 
   getPublishTitle() {
-    return this.props.currentEvent.id ? '更新' : '发布';
+    return this.props.currentEvent.id ? <FormattedMessage id="update" /> : <FormattedMessage id="submit" />;
   }
 
   cancelPublish = () => {

--- a/src/websrc/src/components/Editor/EditorBase.jsx
+++ b/src/websrc/src/components/Editor/EditorBase.jsx
@@ -9,18 +9,18 @@ import classNames from 'classnames/bind';
 import Dialog from '../BaseComponent/PopupComponent';
 import TemplateSelector from './TemplateSelector';
 import styles from '../css/editor.scss';
-import Preview from '../DashboardComponent/PreviewComponent'
+import Preview from '../DashboardComponent/PreviewComponent';
 
 const cx = classNames.bind(styles);
 const previewImg = require('../../image/preview.png');
 
 const imageURLMap = {
-  style1 : 0,
-  style2 : 1,
-  style3 : 2,
-  style4 : 3,
-  style5 : 4,
-  style6 : 5
+  style1: 0,
+  style2: 1,
+  style3: 2,
+  style4: 3,
+  style5: 4,
+  style6: 5,
 };
 
 const indexToStyle = {
@@ -29,7 +29,7 @@ const indexToStyle = {
   2: 'style3',
   3: 'style4',
   4: 'style5',
-  5: 'style6'
+  5: 'style6',
 };
 
 const DEFAULT_OWNER = 'admin';
@@ -49,20 +49,20 @@ class EditorBase extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState({currentEvent: this.getInitialEvent(nextProps), selectedTemplateId: this.getSelectedTemplateId(nextProps.currentEvent)});
+    this.setState({ currentEvent: this.getInitialEvent(nextProps), selectedTemplateId: this.getSelectedTemplateId(nextProps.currentEvent) });
   }
 
   getInitialEvent(nextProps) {
-    return nextProps.currentEvent.id ? nextProps.currentEvent : {type: this.getEditorType(), owner: DEFAULT_OWNER, display_time: DEFAULT_DISPLAY_TIME, imageURL: DEFAULT_IMAGE_URL};
+    return nextProps.currentEvent.id ? nextProps.currentEvent : { type: this.getEditorType(), owner: DEFAULT_OWNER, display_time: DEFAULT_DISPLAY_TIME, imageURL: DEFAULT_IMAGE_URL };
   };
 
   render() {
     return (
       <form noValidate="noValidate" id="editorForm" className={cx('formContainer')} onSubmit={(event) => event.preventDefault()}>
         {this.onRenderContent(this.getEventAttribute)}
-        <TemplateSelector onSelect={ this.onTemplateSelect } selectedTemplate={this.getSelectedTemplateId(this.state.currentEvent)} />
+        <TemplateSelector onSelect={this.onTemplateSelect} selectedTemplate={this.getSelectedTemplateId(this.state.currentEvent)} />
         <div className={cx('previewBlock')}>
-          <div className={cx('preview')} onClick={ this.handlePreviewDetailClick }>
+          <div className={cx('preview')} onClick={this.handlePreviewDetailClick}>
             <img
               alt=""
               className={cx('previewIcon')}
@@ -71,11 +71,11 @@ class EditorBase extends React.Component {
           </div>
         </div>
         <div className={cx('newsSubmit')}>
-          <button type="button" className={cx('publish')} onClick={this.publishEvent}>{ this.getPublishTitle() }</button>
-          <button type="button" className={cx('cancelPublish')} onClick={ this.cancelPublish}><FormattedMessage id="cancel" /></button>
+          <button type="button" className={cx('publish')} onClick={this.publishEvent}>{this.getPublishTitle()}</button>
+          <button type="button" className={cx('cancelPublish')} onClick={this.cancelPublish}><FormattedMessage id="cancel" /></button>
         </div>
         <Preview
-          ref={ preview => this.preview = preview }>
+          ref={preview => this.preview = preview}>
         </Preview>
         <Dialog
           ref='dialog'
@@ -84,7 +84,7 @@ class EditorBase extends React.Component {
           message="确认要发布这篇公告吗？"
           positiveText="确认"
           negativeText="取消"
-          onPositiveClick={ this.handleSubmit}
+          onPositiveClick={this.handleSubmit}
         />
         <Dialog
           ref='dialog'
@@ -93,8 +93,8 @@ class EditorBase extends React.Component {
           message="确认要取消发布这篇公告吗?"
           positiveText="确认"
           negativeText="取消"
-          onPositiveClick={ this.backToDashboard }
-          />
+          onPositiveClick={this.backToDashboard}
+        />
         <Dialog
           ref='dialog'
           id="updateActivity"
@@ -102,7 +102,7 @@ class EditorBase extends React.Component {
           message="确认要更新这篇公告吗？"
           positiveText="确认"
           negativeText="取消"
-          onPositiveClick={ this.handleUpdate }
+          onPositiveClick={this.handleUpdate}
         />
         <Dialog
           ref='dialog'
@@ -111,7 +111,7 @@ class EditorBase extends React.Component {
           message="确认要取消更新这篇公告吗？"
           positiveText="确认"
           negativeText="取消"
-          onPositiveClick={ this.backToDashboard }
+          onPositiveClick={this.backToDashboard}
         />
       </form>
     );
@@ -126,7 +126,7 @@ class EditorBase extends React.Component {
   }
 
   cancelPublish = () => {
-    this.refs.dialog.showDialog( this.props.currentEvent ? 'cancelUpdate' : 'cancelPublish');
+    this.refs.dialog.showDialog(this.props.currentEvent ? 'cancelUpdate' : 'cancelPublish');
   };
 
   backToDashboard() {
@@ -169,7 +169,7 @@ class EditorBase extends React.Component {
   onTemplateSelect = (templateId) => {
     let currentEvent = this.state.currentEvent;
     currentEvent.imageURL = indexToStyle[templateId];
-    this.setState({ selectedTemplateId: templateId, currentEvent: currentEvent});
+    this.setState({ selectedTemplateId: templateId, currentEvent: currentEvent });
   };
 
   initValidator() {
@@ -227,11 +227,11 @@ class EditorBase extends React.Component {
     return (
       <div className={cx('timeBlock')}>
         <DatePicker
-          inputProps={{ name: 'startDay', readOnly: 'readonly' } } className={cx('newsTimeDay')}
-          viewMode="days" dateFormat="YYYY-MM-DD" timeFormat={ false }
+          inputProps={{ name: 'startDay', readOnly: 'readonly' }} className={cx('newsTimeDay')}
+          viewMode="days" dateFormat="YYYY-MM-DD" timeFormat={false}
           value={this.getDateString("startTime")}
           onChange={(selectedTime) => this.handleDateChange(selectedTime, 'startTime')}
-          isValidDate={ currentDate => currentDate.diff(now, 'days') >= 0} />
+          isValidDate={currentDate => currentDate.diff(now, 'days') >= 0} />
         <DatePicker
           inputProps={{ name: 'startHour' }} className={cx('newsTimeHour')}
           value={this.getTimeString("startTime")}
@@ -288,7 +288,7 @@ class EditorBase extends React.Component {
   }
 
   getActivity(status) {
-    return JSON.stringify(Object.assign(this.state.currentEvent, {status: status}));
+    return JSON.stringify(Object.assign(this.state.currentEvent, { status: status }));
 
   }
 
@@ -302,7 +302,7 @@ class EditorBase extends React.Component {
 
   getDateString(attrName) {
     let currentEvent = this.state.currentEvent;
-    return currentEvent && currentEvent[attrName] && currentEvent[attrName].substr(0,10);
+    return currentEvent && currentEvent[attrName] && currentEvent[attrName].substr(0, 10);
   }
 
   getTimeString(attrName) {
@@ -315,7 +315,7 @@ class EditorBase extends React.Component {
     const value = target.type === 'checkbox' ? target.checked : target.value;
     const name = target.name;
     this.setState({
-      currentEvent: Object.assign(this.state.currentEvent, {[name]: value})
+      currentEvent: Object.assign(this.state.currentEvent, { [name]: value })
     });
   }
 
@@ -327,7 +327,7 @@ class EditorBase extends React.Component {
       existingTime = ' ' + dateTime.substr(11);
     }
     this.setState({
-      currentEvent: Object.assign(this.state.currentEvent, {[attrName]: selectedDate + existingTime})
+      currentEvent: Object.assign(this.state.currentEvent, { [attrName]: selectedDate + existingTime })
     });
   }
 
@@ -336,10 +336,10 @@ class EditorBase extends React.Component {
     let selectedTime = time.format('HH:mm');
     let existingDate = '';
     if (dateTime) {
-      existingDate = dateTime.substr(0, 10)  + ' ' ;
+      existingDate = dateTime.substr(0, 10) + ' ';
     }
     this.setState({
-      currentEvent: Object.assign(this.state.currentEvent, {[attrName]: existingDate + selectedTime})
+      currentEvent: Object.assign(this.state.currentEvent, { [attrName]: existingDate + selectedTime })
     });
   }
 

--- a/src/websrc/src/components/Editor/EventEditor.jsx
+++ b/src/websrc/src/components/Editor/EventEditor.jsx
@@ -1,22 +1,29 @@
-import React from "react";
-import classNames from "classnames/bind";
-import Nav from "./PublishmentNavigator";
-import ActivityEditor from "./ActivityEditor";
-import NewsEditor from "./NewsEditor";
-import Header from "../Header/index";
-import styles from "../css/editor.scss";
-import activityService from "../services/ActivityApiService";
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
+import Nav from './PublishmentNavigator';
+import ActivityEditor from './ActivityEditor';
+import NewsEditor from './NewsEditor';
+import Header from '../Header/index';
+import styles from '../css/editor.scss';
+import activityService from '../services/ActivityApiService';
 
 const cx = classNames.bind(styles);
-const editorsIndex = {SESSION: 0, NEWS: 1};
+const editorsIndex = { SESSION: 0, NEWS: 1 };
 
 export default class PublishActivity extends React.Component {
+
+  static propTypes = {
+    params: PropTypes.shape({
+      id: PropTypes.number,
+    }).isRequired,
+  };
 
   constructor(props) {
     super(props);
     this.state = {
       selectedTab: 0,
-      currentEvent: {}
+      currentEvent: {},
     };
   }
 
@@ -30,7 +37,10 @@ export default class PublishActivity extends React.Component {
         <Header />
         <div className={cx('contentContainer')}>
           <div className={cx('content')}>
-            <Nav onSelect={index => this.handleSelect(index)} isUpdate={this.isUpdate()} selectedIndex={this.getSelectedTabIndex()}/>
+            <Nav
+              onSelect={index => this.handleSelect(index)}
+              isUpdate={this.isUpdate()}
+              selectedIndex={this.getSelectedTabIndex()} />
             { this.getSelectedEditor(this.state.selectedTab) }
           </div>
         </div>
@@ -39,11 +49,10 @@ export default class PublishActivity extends React.Component {
   }
 
   getSelectedEditor(selectedTab) {
-    if (0 === selectedTab) {
+    if (selectedTab === 0) {
       return <ActivityEditor currentEvent={ this.state.currentEvent } />;
-    } else {
-      return <NewsEditor currentEvent={ this.state.currentEvent } />;
     }
+    return <NewsEditor currentEvent={ this.state.currentEvent } />;
   }
 
   handleSelect(selectedKey) {
@@ -55,8 +64,7 @@ export default class PublishActivity extends React.Component {
   }
 
   getSelectedTabIndex() {
-    let selectedEvent = this.state.currentEvent;
-    return selectedEvent.type ? editorsIndex[selectedEvent.type] : 0;
+    return this.state.selectedTab;
   }
 
   isUpdate() {
@@ -66,10 +74,10 @@ export default class PublishActivity extends React.Component {
   initEvent(eventId) {
     if (eventId) {
       activityService.selectActivity(eventId, (data) => {
-        this.setState({selectedTab: editorsIndex[data.type], currentEvent: data});
+        this.setState({ selectedTab: editorsIndex[data.type], currentEvent: data });
       });
     } else {
-      this.setState({currentEvent: {}, selectedTab: 0});
+      this.setState({ currentEvent: {}, selectedTab: 0 });
     }
   }
 

--- a/src/websrc/src/components/Editor/NewsEditor.jsx
+++ b/src/websrc/src/components/Editor/NewsEditor.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import 'jquery-validation';
 import classNames from 'classnames/bind';
 
@@ -20,7 +21,7 @@ class NewsEditor extends EditorBase {
     return (
       <div>
         <div className={cx('inputBlock')}>
-          {this.getInputName('新闻名称', true)}
+          {this.getInputName(<FormattedMessage id="news_name" />, true)}
           <div>
             <input
               name="name" className={cx('newsNameInput')} type="text"
@@ -30,14 +31,14 @@ class NewsEditor extends EditorBase {
           </div>
         </div>
         <div className={cx('inputBlock')}>
-          {this.getInputName('展示时间', true)}
+          {this.getInputName(<FormattedMessage id="display_time_range" />, true)}
           <div>
             {this.getDateInput()}
-            <div className='invalidTimeError'>活动时间不能为空且结束时间不能早于开始时间</div>
+            <div className='invalidTimeError'><FormattedMessage id="invalid_time_error" /></div>
           </div>
         </div>
         <div className={cx('inputBlock')}>
-          {this.getInputName('新闻内容', true)}
+          {this.getInputName(<FormattedMessage id="news_content" />, true)}
           <div>
             <textarea
               name="description" className={cx('newsDescriptionInput')} type="text"

--- a/src/websrc/src/components/Editor/PublishmentNavigator/index.jsx
+++ b/src/websrc/src/components/Editor/PublishmentNavigator/index.jsx
@@ -8,7 +8,8 @@ const cx = classNames.bind(styles);
 class Navigator extends React.Component {
   static propTypes = {
     onSelect: PropTypes.func.isRequired,
-    isUpdate: PropTypes.bool
+    isUpdate: PropTypes.bool.isRequired,
+    selectedIndex: PropTypes.number.isRequired,
   };
 
   constructor(props) {
@@ -26,26 +27,30 @@ class Navigator extends React.Component {
     return (
       <div className={cx('navBlock')}>
         <nav className={cx('navigation')}>
-          { this.shouldShowTab(0) && (
-              <div className={cx('activityNavBlock')}>
-                <button
-                  className={cx(this.state.selectedIndex === 0 ? 'activityNavSelected' : 'activityNav')}
-                  onClick={() => this.onSelectNav(0)}>
-                  {this.getActivityTabTitle()}
-                </button>
-              </div>
-            )
-          }
-          { this.shouldShowTab(1) && (
-              <div className={cx('activityNavBlock')}>
-                <button
-                  className={cx(this.state.selectedIndex === 1 ? 'newsNavSelected' : 'newsNav')}
-                  onClick={() => this.onSelectNav(1)}>
-                  {this.getNewsTabTitle()}
-                </button>
-              </div>
-            )
-          }
+          {this.shouldShowTab(0) && (
+            <div className={cx('activityNavBlock')}>
+              <button
+                className={cx(this.state.selectedIndex === 0
+                ? 'activityNavSelected'
+                : 'activityNav')}
+                onClick={() => this.onSelectNav(0)}>
+                {this.getActivityTabTitle()}
+              </button>
+            </div>
+          )
+}
+          {this.shouldShowTab(1) && (
+            <div className={cx('activityNavBlock')}>
+              <button
+                className={cx(this.state.selectedIndex === 1
+                ? 'newsNavSelected'
+                : 'newsNav')}
+                onClick={() => this.onSelectNav(1)}>
+                {this.getNewsTabTitle()}
+              </button>
+            </div>
+          )
+}
         </nav>
         <div className={cx('horizontalLine')} />
       </div>
@@ -64,11 +69,11 @@ class Navigator extends React.Component {
   }
 
   getActivityTabTitle() {
-    return this.props.isUpdate ? '更新活动' :'发布活动';
+    return this.props.isUpdate ? '更新活动' : '发布活动';
   }
 
   getNewsTabTitle() {
-    return this.props.isUpdate ? '更新新闻' :'发布新闻';
+    return this.props.isUpdate ? '更新新闻' : '发布新闻';
   }
 
 }

--- a/src/websrc/src/components/Editor/PublishmentNavigator/index.jsx
+++ b/src/websrc/src/components/Editor/PublishmentNavigator/index.jsx
@@ -8,7 +8,8 @@ const cx = classNames.bind(styles);
 class Navigator extends React.Component {
   static propTypes = {
     onSelect: PropTypes.func.isRequired,
-    isUpdate: PropTypes.bool
+    isUpdate: PropTypes.bool.isRequired,
+    selectedIndex: PropTypes.number.isRequired,
   };
 
   constructor(props) {
@@ -19,32 +20,36 @@ class Navigator extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState({isUpdate: nextProps.isUpdate, selectedIndex: nextProps.selectedIndex});
+    this.setState({ isUpdate: nextProps.isUpdate, selectedIndex: nextProps.selectedIndex });
   }
 
   render() {
     return (
       <div className={cx('navBlock')}>
         <nav className={cx('navigation')}>
-          { this.shouldShowTab(0) && (
-              <div className={cx('activityNavBlock')}>
-                <button
-                  className={cx(this.state.selectedIndex === 0 ? 'activityNavSelected' : 'activityNav')}
-                  onClick={() => this.onSelectNav(0)}>
-                  {this.getActivityTabTitle()}
-                </button>
-              </div>
-            )
+          {this.shouldShowTab(0) && (
+            <div className={cx('activityNavBlock')}>
+              <button
+                className={cx(this.state.selectedIndex === 0
+                  ? 'activityNavSelected'
+                  : 'activityNav')}
+                onClick={() => this.onSelectNav(0)}>
+                {this.getActivityTabTitle()}
+              </button>
+            </div>
+          )
           }
-          { this.shouldShowTab(1) && (
-              <div className={cx('activityNavBlock')}>
-                <button
-                  className={cx(this.state.selectedIndex === 1 ? 'newsNavSelected' : 'newsNav')}
-                  onClick={() => this.onSelectNav(1)}>
-                  {this.getNewsTabTitle()}
-                </button>
-              </div>
-            )
+          {this.shouldShowTab(1) && (
+            <div className={cx('activityNavBlock')}>
+              <button
+                className={cx(this.state.selectedIndex === 1
+                  ? 'newsNavSelected'
+                  : 'newsNav')}
+                onClick={() => this.onSelectNav(1)}>
+                {this.getNewsTabTitle()}
+              </button>
+            </div>
+          )
           }
         </nav>
         <div className={cx('horizontalLine')} />
@@ -64,11 +69,11 @@ class Navigator extends React.Component {
   }
 
   getActivityTabTitle() {
-    return this.props.isUpdate ? '更新活动' :'发布活动';
+    return this.props.isUpdate ? '更新活动' : '发布活动';
   }
 
   getNewsTabTitle() {
-    return this.props.isUpdate ? '更新新闻' :'发布新闻';
+    return this.props.isUpdate ? '更新新闻' : '发布新闻';
   }
 
 }

--- a/src/websrc/src/components/Editor/PublishmentNavigator/index.jsx
+++ b/src/websrc/src/components/Editor/PublishmentNavigator/index.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import styles from '../../css/editor.scss';
 
@@ -6,8 +7,8 @@ const cx = classNames.bind(styles);
 
 class Navigator extends React.Component {
   static propTypes = {
-    onSelect: React.PropTypes.func.isRequired,
-    isUpdate: React.PropTypes.bool
+    onSelect: PropTypes.func.isRequired,
+    isUpdate: PropTypes.bool
   };
 
   constructor(props) {

--- a/src/websrc/src/components/Editor/PublishmentNavigator/index.jsx
+++ b/src/websrc/src/components/Editor/PublishmentNavigator/index.jsx
@@ -14,7 +14,7 @@ class Navigator extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      selectedIndex: props.selectedIndex
+      selectedIndex: props.selectedIndex,
     };
   }
 
@@ -60,7 +60,7 @@ class Navigator extends React.Component {
   }
 
   shouldShowTab(index) {
-    return !(this.props.isUpdate && this.state.selectedIndex !== index)
+    return !(this.props.isUpdate && this.state.selectedIndex !== index);
   }
 
   getActivityTabTitle() {

--- a/src/websrc/src/components/Editor/TemplateSelector/index.jsx
+++ b/src/websrc/src/components/Editor/TemplateSelector/index.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 
@@ -41,7 +42,7 @@ class TemplateSelector extends Component {
   render() {
     return (
       <div className={cx('templateSelectBlock')}>
-        {TemplateSelector.getInputName('选择模板', true)}
+        {TemplateSelector.getInputName(<FormattedMessage id="choose_template" />, true)}
         {this.getTemplates(this.state.templates)}
       </div>
     );

--- a/src/websrc/src/components/Editor/locale/zh.js
+++ b/src/websrc/src/components/Editor/locale/zh.js
@@ -1,0 +1,17 @@
+export default {
+  news_name: '新闻名称',
+  display_time_range: '展示时间',
+  news_content: '新闻内容',
+  choose_template: '选择模板',
+  session_name: '活动名称',
+  session_time_range: '活动时间',
+  session_location: '活动地点',
+  session_host: '主办方',
+  session_guest: '活动嘉宾',
+  session_description: '活动描述',
+  preview: '预览看看',
+  cancel: '取消',
+  submit: '发布',
+  update: '更新',
+  invalid_time_error: '活动时间不能为空且结束时间不能早于开始时间'
+};

--- a/src/websrc/src/components/Header/index.jsx
+++ b/src/websrc/src/components/Header/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {Link} from "react-router";
+import { Link } from 'react-router';
+import { FormattedMessage } from 'react-intl';
 import classNames from 'classnames/bind';
 import styles from '../css/header.scss';
 
@@ -25,7 +26,7 @@ class Header extends React.Component {
             17 High
           </div>
           <div className={cx('launch')}>
-            <button className={cx('launchText')}><Link to={ 'editor'}>发布公告</Link></button>
+            <button className={cx('launchText')}><Link to={ 'editor'}><FormattedMessage id="post_notice" /></Link></button>
           </div>
 
           <div className={cx('rightContainer')}>

--- a/src/websrc/src/components/Header/locale/zh.js
+++ b/src/websrc/src/components/Header/locale/zh.js
@@ -1,0 +1,3 @@
+export default {
+  post_notice: '发布公告'
+};

--- a/src/websrc/src/components/ScreenComponent/DetailComponent.jsx
+++ b/src/websrc/src/components/ScreenComponent/DetailComponent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 import scss from './ScreenComponent.scss';
@@ -15,6 +16,8 @@ const DetailComponent = (props) => {
   if (item.type === 'NEWS') {
     typeicon = NewsIcon;
     hideNewsField = scss.hideinfo;
+  } else {
+    item.type = 'SESSION';
   }
 
   return (
@@ -52,17 +55,17 @@ const DetailComponent = (props) => {
 };
 
 DetailComponent.propTypes = {
-  activity: React.PropTypes.shape({
-    sponsor: React.PropTypes.string,
-    location: React.PropTypes.string,
-    guest: React.PropTypes.string,
-    description: React.PropTypes.string,
-    endTime: React.PropTypes.date,
-    name: React.PropTypes.string,
-    type: React.PropTypes.string,
-    imageURL: React.PropTypes.string
+  activity: PropTypes.shape({
+    sponsor: PropTypes.string,
+    location: PropTypes.string,
+    guest: PropTypes.string,
+    description: PropTypes.string,
+    endTime: PropTypes.date,
+    name: PropTypes.string,
+    type: PropTypes.string,
+    imageURL: PropTypes.string
   }).isRequired,
-  addition: React.PropTypes.string.isRequired
+  addition: PropTypes.string.isRequired
 };
 
 

--- a/src/websrc/src/components/ScreenComponent/DetailComponent.jsx
+++ b/src/websrc/src/components/ScreenComponent/DetailComponent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 import scss from './ScreenComponent.scss';
 import NewsIcon from './svg/NewsIcon';
@@ -9,11 +10,9 @@ import DateUtil from './DateUtils';
 const DetailComponent = (props) => {
   const item = props.activity;
   const style = classNames(scss.detaildiv, scss[item.imageURL]);
-  let typeText = '活动';
   let hideNewsField = '';
   let typeicon = ActivityIcon;
   if (item.type === 'NEWS') {
-    typeText = '新闻';
     typeicon = NewsIcon;
     hideNewsField = scss.hideinfo;
   }
@@ -22,7 +21,7 @@ const DetailComponent = (props) => {
     <div className={style} data-additionflag={props.addition}>
       <div className={classNames(scss.typediv)}>
         { typeicon({ className: classNames(scss.labelIcon) }) }
-        <span className={classNames(scss.typetext)}>{typeText}</span>
+        <span className={classNames(scss.typetext)}><FormattedMessage id={item.type} /></span>
       </div>
       <div className={classNames(scss.logoIconWrapper)}>
         <LogoIcon className={classNames(scss.logoIcon)} />
@@ -39,10 +38,10 @@ const DetailComponent = (props) => {
         <span className={classNames(scss.locationdivtext)}>{item.location}</span>
       </div>
       <div className={classNames(scss.ownerdiv, hideNewsField)}>
-        <span>主办方:</span>
+        <span><FormattedMessage id="hold_by" />:</span>
         <span>{item.sponsor}</span>
         /
-        <span>活动嘉宾:</span>
+        <span><FormattedMessage id="guest" />:</span>
         <span>{item.guest}</span>
       </div>
       <div className={classNames(scss.describediv)}>

--- a/src/websrc/src/components/ScreenComponent/ItemComponent.jsx
+++ b/src/websrc/src/components/ScreenComponent/ItemComponent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import scss from './ScreenComponent.scss';
 import DateUtils from './DateUtils';
@@ -20,18 +21,18 @@ const ItemComponent = (props) => {
 };
 
 ItemComponent.propTypes = {
-  activity: React.PropTypes.shape({
-    sponsor: React.PropTypes.string,
-    location: React.PropTypes.string,
-    guest: React.PropTypes.string,
-    description: React.PropTypes.string,
-    startTime: React.PropTypes.date,
-    endTime: React.PropTypes.date,
-    name: React.PropTypes.string,
-    type: React.PropTypes.string,
-    imageURL: React.PropTypes.string
+  activity: PropTypes.shape({
+    sponsor: PropTypes.string,
+    location: PropTypes.string,
+    guest: PropTypes.string,
+    description: PropTypes.string,
+    startTime: PropTypes.date,
+    endTime: PropTypes.date,
+    name: PropTypes.string,
+    type: PropTypes.string,
+    imageURL: PropTypes.string
   }).isRequired,
-  active: React.PropTypes.bool.isRequired
+  active: PropTypes.bool.isRequired
 };
 
 export default ItemComponent;

--- a/src/websrc/src/components/ScreenComponent/RecentComponent.jsx
+++ b/src/websrc/src/components/ScreenComponent/RecentComponent.jsx
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import scss from './ScreenComponent.scss';
 import ItemComponent from './ItemComponent';
 import ActivityApiService from './../services/ActivityApiService';
-
 
 class RecentComponent extends Component {
   static propTypes = {
@@ -42,7 +42,7 @@ class RecentComponent extends Component {
     ));
     return (
       <div className={classNames(scss.recentdiv)}>
-        <button className={classNames(scss.recenttext)} onClick={ this.stopLoop }>近期活动</button>
+        <button className={classNames(scss.recenttext)} onClick={ this.stopLoop }><FormattedMessage id="recent" /></button>
         <div className={classNames(scss.recentlistdiv)}>
           {items}
         </div>

--- a/src/websrc/src/components/ScreenComponent/locale/zh.js
+++ b/src/websrc/src/components/ScreenComponent/locale/zh.js
@@ -1,0 +1,3 @@
+export default {
+  recent: '近期活动'
+};

--- a/src/websrc/src/components/ScreenComponent/locale/zh.js
+++ b/src/websrc/src/components/ScreenComponent/locale/zh.js
@@ -1,3 +1,7 @@
 export default {
-  recent: '近期活动'
+  recent: '近期活动',
+  hold_by: '主办方',
+  guest: '活动嘉宾',
+  NEWS: '新闻',
+  SESSION: '活动'
 };

--- a/src/websrc/src/components/css/editor.scss
+++ b/src/websrc/src/components/css/editor.scss
@@ -80,6 +80,11 @@
   margin-top: 15px;
 }
 
+.inputCheck {
+  height: 16px;
+  width: 16px;
+}
+
 .templateSelectBlock {
   width: 600px;
   display: flex;

--- a/src/websrc/src/components/services/ActivityApiService.jsx
+++ b/src/websrc/src/components/services/ActivityApiService.jsx
@@ -72,7 +72,7 @@ export default class ActivityApiService {
         xhrFields: { withCredentials: true },
         dataType: 'json',
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
         }
       };
       axios.put(url, requestData, config).then((result) => {

--- a/src/websrc/src/index.jsx
+++ b/src/websrc/src/index.jsx
@@ -1,18 +1,26 @@
-import React from "react";
-import {render} from "react-dom";
-import {Router, Route, hashHistory} from "react-router";
-import DashboardComponent from "./components/DashboardComponent";
-import ScreenComponent from "./components/ScreenComponent";
-import EventNewEditor from "./components/Editor/EventEditor";
+import React from 'react';
+import { render } from 'react-dom';
+import { Router, Route, hashHistory } from 'react-router';
+import { IntlProvider, addLocaleData } from 'react-intl';
+import localeZh from 'react-intl/locale-data/zh';
+import locales from './locale';
+import DashboardComponent from './components/DashboardComponent';
+import ScreenComponent from './components/ScreenComponent';
+import EventNewEditor from './components/Editor/EventEditor';
+
+addLocaleData([...localeZh]);
+
+const locale = 'zh';
 
 render((
-  <Router history={ hashHistory } queryKey="false">
-    <Route path="/" component={ ScreenComponent }/>
-    <Route path="/screen" component={ ScreenComponent }/>
-    <Route path="/home" component={DashboardComponent}/>
-    <Route path="/editor" component={EventNewEditor}>
-      <Route path=":id" component={ EventNewEditor }/>
-    </Route>
-  </Router>
+  <IntlProvider locale={locale} messages={locales[locale]}>
+    <Router history={ hashHistory } queryKey="false">
+      <Route path="/" component={ ScreenComponent } />
+      <Route path="/screen" component={ ScreenComponent } />
+      <Route path="/home" component={DashboardComponent} />
+      <Route path="/editor" component={EventNewEditor}>
+        <Route path=":id" component={ EventNewEditor } />
+      </Route>
+    </Router>
+  </IntlProvider>
 ), document.getElementById('app'));
-

--- a/src/websrc/src/locale.jsx
+++ b/src/websrc/src/locale.jsx
@@ -1,7 +1,10 @@
 import ScreenZh from './components/ScreenComponent/locale/zh';
+import HeaderZh from './components/Header/locale/zh';
+import EditorZh from './components/Editor/locale/zh';
+import DashboardZh from './components/DashboardComponent/locale/zh';
 
 const locals = {
-  zh: Object.assign({}, ScreenZh),
+  zh: Object.assign({}, ScreenZh, HeaderZh, EditorZh, DashboardZh),
   en: Object.assign({})
 };
 

--- a/src/websrc/src/locale.jsx
+++ b/src/websrc/src/locale.jsx
@@ -1,0 +1,8 @@
+import ScreenZh from './components/ScreenComponent/locale/zh';
+
+const locals = {
+  zh: Object.assign({}, ScreenZh),
+  en: Object.assign({})
+};
+
+export default locals;

--- a/src/websrc/webpack.config.js
+++ b/src/websrc/webpack.config.js
@@ -58,6 +58,7 @@ const config = {
     }),
     extractCSS
   ],
+  devtool: 'source-map'
 };
 
 module.exports = config;

--- a/src/websrc/webpack.config.js
+++ b/src/websrc/webpack.config.js
@@ -34,7 +34,7 @@ const config = {
         test: /\.scss$/,
         loader: extractCSS.extract(['css?minimize&modules&importLoaders=2&localIdentName=[name]__[local]', 'postcss', 'sass']),
       },
-      {test: /\.json$/, loader: 'json'},
+      { test: /\.json$/, loader: 'json' },
       {
         test: /\.(jpe?g|png|gif|svg)$/i,
         loaders: [

--- a/src/websrc/yarn.lock
+++ b/src/websrc/yarn.lock
@@ -1901,6 +1901,10 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deepmerge@^1.3.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.0.tgz#00bc5b88fd23b8130f9f5049071c3420e07a5465"
+
 default-require-extensions@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
@@ -5789,6 +5793,13 @@ react-onclickoutside@^5.9.0:
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-5.11.1.tgz#00314e52567cf55faba94cabbacd119619070623"
   dependencies:
     create-react-class "^15.5.x"
+
+react-popupbox@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-popupbox/-/react-popupbox-2.0.1.tgz#ba153118c0538269a16e11969b04763227453e65"
+  dependencies:
+    deepmerge "^1.3.2"
+    react "^15.4.2"
 
 react-router@^2.8.1:
   version "2.8.1"

--- a/src/websrc/yarn.lock
+++ b/src/websrc/yarn.lock
@@ -1616,6 +1616,14 @@ create-error-class@^3.0.1:
   dependencies:
     capture-stack-trace "^1.0.0"
 
+create-react-class@^15.5.1:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 create-react-class@^15.5.2, create-react-class@^15.5.x:
   version "15.5.2"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.5.2.tgz#6a8758348df660b88326a0e764d569f274aad681"
@@ -1888,10 +1896,6 @@ decompress@^3.0.0:
     stream-combiner2 "^1.1.1"
     vinyl-assign "^1.0.1"
     vinyl-fs "^2.2.0"
-
-deep-equal@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
 deep-extend@~0.4.0:
   version "0.4.1"
@@ -3170,14 +3174,14 @@ he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
-history@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/history/-/history-2.1.2.tgz#4aa2de897a0e4867e4539843be6ecdb2986bfdec"
+history@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-3.3.0.tgz#fcedcce8f12975371545d735461033579a6dae9c"
   dependencies:
-    deep-equal "^1.0.0"
-    invariant "^2.0.0"
-    query-string "^3.0.0"
-    warning "^2.0.0"
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    query-string "^4.2.2"
+    warning "^3.0.0"
 
 hoek@2.x.x:
   version "2.16.3"
@@ -3485,7 +3489,7 @@ intl-relativeformat@^1.3.0:
   dependencies:
     intl-messageformat "1.3.0"
 
-invariant@^2.0.0, invariant@^2.1.1, invariant@^2.2.0, invariant@^2.2.1:
+invariant@^2.1.1, invariant@^2.2.0, invariant@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -4461,7 +4465,7 @@ longest@^1.0.0, longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -5695,6 +5699,13 @@ prop-types@^15.5.0, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@~15.5.7:
   dependencies:
     fbjs "^0.8.9"
 
+prop-types@^15.5.6:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
 proxy-addr@~1.1.3:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.4.tgz#27e545f6960a44a627d9b44467e35c1b6b4ce2f3"
@@ -5730,13 +5741,7 @@ qs@~6.3.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
 
-query-string@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-3.0.3.tgz#ae2e14b4d05071d4e9b9eb4873c35b0dcd42e638"
-  dependencies:
-    strict-uri-encode "^1.0.0"
-
-query-string@^4.1.0:
+query-string@^4.1.0, query-string@^4.2.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
   dependencies:
@@ -5830,14 +5835,16 @@ react-popupbox@^2.0.0:
     deepmerge "^1.3.2"
     react "^15.4.2"
 
-react-router@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-2.8.1.tgz#73e9491f6ceb316d0f779829081863e378ee4ed7"
+react-router@3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.0.5.tgz#c3b7873758045a8bbc9562aef4ff4bc8cce7c136"
   dependencies:
-    history "^2.1.2"
+    create-react-class "^15.5.1"
+    history "^3.0.0"
     hoist-non-react-statics "^1.2.0"
     invariant "^2.2.1"
     loose-envify "^1.2.0"
+    prop-types "^15.5.6"
     warning "^3.0.0"
 
 react@^15.4.2:
@@ -7078,12 +7085,6 @@ ware@^1.2.0:
   resolved "https://registry.yarnpkg.com/ware/-/ware-1.3.0.tgz#d1b14f39d2e2cb4ab8c4098f756fe4b164e473d4"
   dependencies:
     wrap-fn "^0.1.0"
-
-warning@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-2.1.0.tgz#21220d9c63afc77a8c92111e011af705ce0c6901"
-  dependencies:
-    loose-envify "^1.0.0"
 
 warning@^3.0.0:
   version "3.0.0"

--- a/src/websrc/yarn.lock
+++ b/src/websrc/yarn.lock
@@ -3465,7 +3465,27 @@ interpret@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
 
-invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1:
+intl-format-cache@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-2.0.5.tgz#b484cefcb9353f374f25de389a3ceea1af18d7c9"
+
+intl-messageformat-parser@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.2.0.tgz#5906b7f953ab7470e0dc8549097b648b991892ff"
+
+intl-messageformat@1.3.0, intl-messageformat@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-1.3.0.tgz#f7d926aded7a3ab19b2dc601efd54e99a4bd4eae"
+  dependencies:
+    intl-messageformat-parser "1.2.0"
+
+intl-relativeformat@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/intl-relativeformat/-/intl-relativeformat-1.3.0.tgz#893dc7076fccd380cf091a2300c380fa57ace45b"
+  dependencies:
+    intl-messageformat "1.3.0"
+
+invariant@^2.0.0, invariant@^2.1.1, invariant@^2.2.0, invariant@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -5787,6 +5807,15 @@ react-dom@^15.4.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "~15.5.7"
+
+react-intl@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-2.3.0.tgz#e1df6af5667fdf01cbe4aab20e137251e2ae5142"
+  dependencies:
+    intl-format-cache "^2.0.5"
+    intl-messageformat "^1.3.0"
+    intl-relativeformat "^1.3.0"
+    invariant "^2.1.1"
 
 react-onclickoutside@^5.9.0:
   version "5.11.1"


### PR DESCRIPTION
Card:新建每周发生的活动并查看

#上下文
公司有一些重复发生的活动，如每周的游泳，Friday drink，在已有的系统中，这些重复发生的活动需要重复的 手动的创建活动，不方便且费时。
目前希望能够支持创建重复发生的活动，此张卡的为MVP版，仅支持weekly的活动，其他的更多会有enhancement卡。

---

#场景
场景包含在发布活动页面的创建，在screen页面、home 页面的view，以及home页面的排序

- ###Create
_**given**_ 用户点击“发布公告”按钮，
_**when** _用户访问“发布活动”的页面
_**then**_ 用户能看到“活动时间”字段，字段下面有checkbox，显示每周一次
e.g.
用户创建了一个在2017-07-27（周四）天的活动，并点击每周一次，用户创建的活动会在之后每周四发生。

- ###View
_**given**_ 用户发布一个每周发生一次的活动
_**when**_ 用户访问“screen“页面
_**then**_ 用户能够看到发布的每周发生的活动

- ###View
_**given**_ 用户发布一个每周发生一次的活动
_**when**_ 用户访问“home“页面
_**then**_ 用户能够看到发布的活动，显示为一个活动
_**and**_ 用户在home页面对该活动的操作（预览 编辑 删除 播放10s），与对其他活动的行为表现一致

- ###Sort
_**given**_ 用户发布一个每周发生一次的活动
_**when**_ 用户访问“home“页面，用户点击 按活动开始时间 排序
_**then**_ 每周发生的活动按照最近一次即将发生的时间参与排序（和其他不一样）
_**when**_ 用户访问“home“页面，用户点击 按活动发布时间 排序
_**then**_ 每周发生的活动按照其活动发布时间参与排序（和其他一样）

---

#ACs


